### PR TITLE
Update MacSysAdmin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://www.youtube.com/channel/UCiRYn1OSRv2bvU3enNwoZxg
 
 ### MacSysAdmin Sweden
 
-http://documentation.macsysadmin.se/Documentation2017/Documentation.php
+https://documentation.macsysadmin.se/
 
 ### QueryConf (OsQuery)
 


### PR DESCRIPTION
The 2017 link wasn't working anymore, and this one lists all previous years.